### PR TITLE
Added the answer sent on LinkedIn by Amol Palav (https://www.linkedin…

### DIFF
--- a/challenges/challenge1_answer_Amol_Palav.pgsql
+++ b/challenges/challenge1_answer_Amol_Palav.pgsql
@@ -1,0 +1,17 @@
+WITH RECURSIVE cte_rel AS (
+    SELECT meta_id,meta_id::VARCHAR AS hierarchy_id, meta_name AS hierarchy_name, meta_name
+    FROM meta
+    WHERE meta_parent IS NULL
+    UNION ALL
+    SELECT
+        m2.meta_id,c.hierarchy_id ||' -> '||m2.meta_id AS hierarchy_id,c.hierarchy_name ||' -> '||m2.meta_name AS hierarchy_name,
+        m2.meta_name
+    FROM meta m2 JOIN cte_rel c ON m2.meta_parent=c.meta_id
+),
+cte_obj AS (
+    SELECT meta_id, count(*) tot FROM meta_obj GROUP BY meta_id
+)
+SELECT c1.meta_id, c1.hierarchy_id, c1.hierarchy_name, c1.meta_name, coalesce(o.tot,0) AS total
+FROM cte_rel c1 left 
+    OUTER JOIN cte_obj o ON c1.meta_id=o.meta_id
+ORDER BY c1.meta_id;


### PR DESCRIPTION
## Answer to Challenge 1 by Amol Palav

This answer was sent to me on LinkedIn by Amol Palav (https://www.linkedin.com/in/amol-palav/) and consists in a combination of 2 CTEs:

```SQL
WITH RECURSIVE cte_rel AS (
    SELECT meta_id,meta_id::VARCHAR AS hierarchy_id, meta_name AS hierarchy_name, meta_name
    FROM meta
    WHERE meta_parent IS NULL
    UNION ALL
    SELECT
        m2.meta_id,c.hierarchy_id ||' -> '||m2.meta_id AS hierarchy_id,c.hierarchy_name ||' -> '||m2.meta_name AS hierarchy_name,
        m2.meta_name
    FROM meta m2 JOIN cte_rel c ON m2.meta_parent=c.meta_id
),
cte_obj AS (
    SELECT meta_id, count(*) tot FROM meta_obj GROUP BY meta_id
)
SELECT c1.meta_id, c1.hierarchy_id, c1.hierarchy_name, c1.meta_name, coalesce(o.tot,0) AS total
FROM cte_rel c1 left 
    OUTER JOIN cte_obj o ON c1.meta_id=o.meta_id
ORDER BY c1.meta_id;
```

This query runs incredibly fast, **timing avg of 198ms without any auxiliary index** than the PKs in the original tables. If we check the EXPLAIN plan we’ll see that the extra CTE allowed Postgres to run it in parallel. Query parallelization is an amazing feature on Postgres and we can see here how it can help to dramatically improves performance. Just for comparison, my query that I’m using as parameter of comparison runs in a **time avg of 730ms**. I won’t fully comment the query here because I will write a post on the process I usually use to optimize queries and there will use this challenge to run through the process but you can find the EXPLAIN plan below and try to understand why this query runs so fast:

```

                                                                                           QUERY PLAN                                                                                           
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=18327.71..18336.73 rows=3606 width=108) (actual time=1505.188..1505.276 rows=20 loops=1)
   Output: c1.meta_id, c1.hierarchy_id, c1.hierarchy_name, c1.meta_name, (COALESCE(o.tot, '0'::bigint))
   Sort Key: c1.meta_id
   Sort Method: quicksort  Memory: 27kB
   Buffers: shared hit=3090 read=7237
   CTE cte_rel
     ->  Recursive Union  (cost=0.00..468.65 rows=3606 width=100) (actual time=0.015..0.302 rows=20 loops=1)
           Buffers: shared hit=4
           ->  Seq Scan on public.meta  (cost=0.00..22.03 rows=6 width=100) (actual time=0.012..0.021 rows=3 loops=1)
                 Output: meta.meta_id, (meta.meta_id)::character varying, meta.meta_name, meta.meta_name
                 Filter: (meta.meta_parent IS NULL)
                 Rows Removed by Filter: 17
                 Buffers: shared hit=1
           ->  Subquery Scan on "*SELECT* 2"  (cost=1.95..41.05 rows=360 width=100) (actual time=0.042..0.081 rows=6 loops=3)
                 Output: "*SELECT* 2".meta_id, "*SELECT* 2".hierarchy_id, "*SELECT* 2".hierarchy_name, "*SELECT* 2".meta_name
                 Buffers: shared hit=3
                 ->  Hash Join  (cost=1.95..37.45 rows=360 width=100) (actual time=0.039..0.070 rows=6 loops=3)
                       Output: m2.meta_id, (((c.hierarchy_id)::text || ' -> '::text) || (m2.meta_id)::text), (((c.hierarchy_name)::text || ' -> '::text) || (m2.meta_name)::text), m2.meta_name
                       Hash Cond: (m2.meta_parent = c.meta_id)
                       Buffers: shared hit=3
                       ->  Seq Scan on public.meta m2  (cost=0.00..22.00 rows=1200 width=40) (actual time=0.004..0.018 rows=20 loops=3)
                             Output: m2.meta_id, m2.meta_parent, m2.meta_name
                             Buffers: shared hit=3
                       ->  Hash  (cost=1.20..1.20 rows=60 width=68) (actual time=0.014..0.015 rows=7 loops=3)
                             Output: c.hierarchy_id, c.hierarchy_name, c.meta_id
                             Buckets: 1024  Batches: 1  Memory Usage: 9kB
                             ->  WorkTable Scan on cte_rel c  (cost=0.00..1.20 rows=60 width=68) (actual time=0.002..0.007 rows=7 loops=3)
                                   Output: c.hierarchy_id, c.hierarchy_name, c.meta_id
   ->  Hash Left Join  (cost=17564.23..17646.02 rows=3606 width=108) (actual time=1504.823..1505.228 rows=20 loops=1)
         Output: c1.meta_id, c1.hierarchy_id, c1.hierarchy_name, c1.meta_name, COALESCE(o.tot, '0'::bigint)
         Inner Unique: true
         Hash Cond: (c1.meta_id = o.meta_id)
         Buffers: shared hit=3090 read=7237
         ->  CTE Scan on cte_rel c1  (cost=0.00..72.12 rows=3606 width=100) (actual time=0.018..0.329 rows=20 loops=1)
               Output: c1.meta_id, c1.hierarchy_id, c1.hierarchy_name, c1.meta_name
               Buffers: shared hit=4
         ->  Hash  (cost=17564.02..17564.02 rows=17 width=12) (actual time=1504.796..1504.856 rows=17 loops=1)
               Output: o.tot, o.meta_id
               Buckets: 1024  Batches: 1  Memory Usage: 9kB
               Buffers: shared hit=3086 read=7237
               ->  Subquery Scan on o  (cost=17559.54..17564.02 rows=17 width=12) (actual time=1504.649..1504.834 rows=17 loops=1)
                     Output: o.tot, o.meta_id
                     Buffers: shared hit=3086 read=7237
                     ->  Finalize GroupAggregate  (cost=17559.54..17563.85 rows=17 width=12) (actual time=1504.647..1504.807 rows=17 loops=1)
                           Output: meta_obj.meta_id, count(*)
                           Group Key: meta_obj.meta_id
                           Buffers: shared hit=3086 read=7237
                           ->  Gather Merge  (cost=17559.54..17563.51 rows=34 width=12) (actual time=1504.632..1504.748 rows=51 loops=1)
                                 Output: meta_obj.meta_id, (PARTIAL count(*))
                                 Workers Planned: 2
                                 Workers Launched: 2
                                 Buffers: shared hit=3086 read=7237
                                 ->  Sort  (cost=16559.52..16559.56 rows=17 width=12) (actual time=1495.643..1495.659 rows=17 loops=3)
                                       Output: meta_obj.meta_id, (PARTIAL count(*))
                                       Sort Key: meta_obj.meta_id
                                       Sort Method: quicksort  Memory: 25kB
                                       Buffers: shared hit=3086 read=7237
                                       Worker 0:  actual time=1492.943..1492.958 rows=17 loops=1
                                         Sort Method: quicksort  Memory: 25kB
                                         Buffers: shared hit=1017 read=2400
                                       Worker 1:  actual time=1489.585..1489.600 rows=17 loops=1
                                         Sort Method: quicksort  Memory: 25kB
                                         Buffers: shared hit=1049 read=2376
                                       ->  Partial HashAggregate  (cost=16559.00..16559.17 rows=17 width=12) (actual time=1495.593..1495.608 rows=17 loops=3)
                                             Output: meta_obj.meta_id, PARTIAL count(*)
                                             Group Key: meta_obj.meta_id
                                             Batches: 1  Memory Usage: 24kB
                                             Buffers: shared hit=3072 read=7237
                                             Worker 0:  actual time=1492.886..1492.900 rows=17 loops=1
                                               Batches: 1  Memory Usage: 24kB
                                               Buffers: shared hit=1010 read=2400
                                             Worker 1:  actual time=1489.523..1489.539 rows=17 loops=1
                                               Batches: 1  Memory Usage: 24kB
                                               Buffers: shared hit=1042 read=2376
                                             ->  Parallel Seq Scan on public.meta_obj  (cost=0.00..14475.67 rows=416667 width=4) (actual time=0.025..718.764 rows=333333 loops=3)
                                                   Output: meta_obj.obj_id, meta_obj.meta_id, meta_obj.obj_name, meta_obj.obj_json
                                                   Buffers: shared hit=3072 read=7237
                                                   Worker 0:  actual time=0.032..685.474 rows=330770 loops=1
                                                     Buffers: shared hit=1010 read=2400
                                                   Worker 1:  actual time=0.026..728.438 rows=331480 loops=1
                                                     Buffers: shared hit=1042 read=2376
```

One note here, the query sent by Kirk Roybal still runs faster using the index he proposed. I mean, even if I create the index and run this query Kirk's original query is still faster. His query runs in avg time of 80ms and this one 106ms (both using the index) and I will leave it to you guys to explain why the index doesn't give a huge improvement to this query here. One hint, check how Postgres stores data and indexes...
